### PR TITLE
Partition names should be prefixed by "p" for NVMe

### DIFF
--- a/script/config.sh
+++ b/script/config.sh
@@ -87,12 +87,20 @@ else
 export ISEFI=0  # No, BIOS
 fi # is EFI firmaare? 
 
+# Detect drive type.
+# For NVME drives, partition names should be prefixed by p.
+if [[ ${DEV} == *"nvme"* ]] ; then
+export PARTPREFIX="p"  # Yes, NVME
+else
+export PARTPREFIX=""   # No, regular
+fi
+
 # Set partition number based on the firmware type
 if [  ${ISEFI} -ne 0  ] ; then 
 # EFI firmware
-export EFIPARTITION=1
-export CRYPTPARTITION=2
+export EFIPARTITION=${PARTPREFIX}1
+export CRYPTPARTITION=${PARTPREFIX}2
 else
 # BIOS firmware
-export CRYPTPARTITION=1
+export CRYPTPARTITION=${PARTPREFIX}1
 fi  # EFI firmware


### PR DESCRIPTION
Hi.

My setup involves a NVMe drive and I found out that the script did not set the partition names correctly in that case
Indeed, for NVMe drives, the partition names should be "p1" and "p2" instead of "1" and "2".

I do not know if the change that I did is very reliable though
 have seen it done like this in some other script, but perhaps not all drives have their names laid out like this.

I will let you judge whether this is good enough or if the script should have an extra configuration parameter set manually by the user.

Anyway, thanks for developing this script, I did a Void Linux installation with it and it is really a life changer!